### PR TITLE
feat: enhance transport arguments for external extension loading

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -364,6 +364,9 @@ export function buildTransportArgs(): string[] {
       args.push("--ignore-default-chrome-arg=--disable-extensions");
       args.push("--ignore-default-chrome-arg=--disable-component-extensions-with-background-pages");
       args.push("--show-component-extension-options");
+      // Allow external extension loader and download services
+      args.push("--ignore-default-chrome-arg=--disable-default-apps");
+      args.push("--ignore-default-chrome-arg=--disable-background-networking");
     } else {
       args.push("--isolated");
     }


### PR DESCRIPTION
This change adds two additional `--ignore-default-chrome-arg` flags to buildTransportArgs() when a persistent user data directory (`userDataDir`) is configured. Specifically, it removes Puppeteer's default `--disable-default-apps` and `--disable-background-networking` flags from the launched browser.

###  Why
When using a persistent profile (--userDataDir), users expect extensions to be available and functional. The existing code already un-blocked --disable-extensions and --disable-component-extensions-with-background-pages, but extensions that rely on the default app infrastructure or need background network access (e.g., for downloading/updating) were still silently broken. This change completes the set of overrides needed for full extension support in persistent-profile mode.