### PR TITLE
fix: require opera-devtools-mcp 0.4.0 for MCP Hub support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@modelcontextprotocol/sdk": "^1.12.1",
         "@toon-format/toon": "^2.1.0",
         "axi-sdk-js": "^0.1.4",
-        "opera-devtools-mcp": "^0.3.0"
+        "opera-devtools-mcp": "^0.4.0"
       },
       "bin": {
         "opera-browser-cli": "dist/bin/opera-browser-cli.js"
@@ -1980,9 +1980,9 @@
       }
     },
     "node_modules/opera-devtools-mcp": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/opera-devtools-mcp/-/opera-devtools-mcp-0.3.0.tgz",
-      "integrity": "sha512-P5tcfFiPAjqXpXW4vLPHjqKZK9wS8nq68NsCfGnrmzXk4x70r+4h5rE1hfh7tN++tSHrC7APfwJ/XmcqO6W+WQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/opera-devtools-mcp/-/opera-devtools-mcp-0.4.0.tgz",
+      "integrity": "sha512-txP47buXHzMUc6pSeij9rtBHWVnue6vHc0qerHldesYJX7SGtoxlZ0cTbSwzMuNd6eTphkjvSN7yT9D+LtI0xA==",
       "license": "Apache-2.0",
       "bin": {
         "opera-devtools": "build/src/bin/opera-devtools.js",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@modelcontextprotocol/sdk": "^1.12.1",
     "@toon-format/toon": "^2.1.0",
     "axi-sdk-js": "^0.1.4",
-    "opera-devtools-mcp": "^0.3.0"
+    "opera-devtools-mcp": "^0.4.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",


### PR DESCRIPTION
## Summary

Bumps the runtime `opera-devtools-mcp` dependency from `^0.3.0` to `^0.4.0`.

## Why

`0.3.0` does **not** contain the MCP Hub tools (`opera_list_mcp_servers`, `opera_list_mcp_tools`, `opera_call_mcp_tool`) that the MCP Hub CLI commands (merged in #25, released in 0.1.47) call. So a fresh install of 0.1.47 gets an MCP server that can't serve those commands.

`0.4.0` (the installed/verified version) contains the MCP Hub tools; the lockfile now pins it.

## Changes

- `package.json`: `"opera-devtools-mcp": "^0.3.0"` → `"^0.4.0"`
- `package-lock.json`: updated to pin `0.4.0`

Version intentionally left at `0.1.47` — release-please will bump to `0.1.48` on merge (this is a `fix:` commit), producing a corrected published bundle.

## Testing

- `tsc --noEmit` clean; `npm run build` passes.
- Full suite: **455 passing** against opera-devtools-mcp@0.4.0.
- `npm pack` tarball verified to declare `opera-devtools-mcp: ^0.4.0`.
