### PR TITLE
fix: require opera-devtools-mcp 0.5.0 for MCP server lifecycle commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@modelcontextprotocol/sdk": "^1.12.1",
         "@toon-format/toon": "^2.1.0",
         "axi-sdk-js": "^0.1.4",
-        "opera-devtools-mcp": "^0.4.0"
+        "opera-devtools-mcp": "^0.5.0"
       },
       "bin": {
         "opera-browser-cli": "dist/bin/opera-browser-cli.js"
@@ -1980,9 +1980,9 @@
       }
     },
     "node_modules/opera-devtools-mcp": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/opera-devtools-mcp/-/opera-devtools-mcp-0.4.0.tgz",
-      "integrity": "sha512-txP47buXHzMUc6pSeij9rtBHWVnue6vHc0qerHldesYJX7SGtoxlZ0cTbSwzMuNd6eTphkjvSN7yT9D+LtI0xA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/opera-devtools-mcp/-/opera-devtools-mcp-0.5.0.tgz",
+      "integrity": "sha512-fJ0aPGmG/dslSTCezC3Q13RpCRLp6XBBwlOiTBbtXwdprIiw/q2istRXNbvqdw+LVGy2fCkHTnVraep5IT2YJg==",
       "license": "Apache-2.0",
       "bin": {
         "opera-devtools": "build/src/bin/opera-devtools.js",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@modelcontextprotocol/sdk": "^1.12.1",
     "@toon-format/toon": "^2.1.0",
     "axi-sdk-js": "^0.1.4",
-    "opera-devtools-mcp": "^0.4.0"
+    "opera-devtools-mcp": "^0.5.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",


### PR DESCRIPTION
## Summary
- #31 added mcp-add/mcp-auth/mcp-remove/mcp-enable/mcp-disable, which call opera_register_mcp_server, opera_connect_mcp_server, opera_authenticate_mcp_server, opera_unregister_mcp_server, opera_enable_mcp_server, and opera_disable_mcp_server
- package.json still pinned `opera-devtools-mcp` to `^0.4.0`, which doesn't have those tools — bump to `^0.5.0` (confirmed published on npm and containing all six tools) so a fresh/updated install actually resolves a compatible version
- package-lock.json regenerated to match

## Test plan
- [x] `npm run build`
- [x] `npm test` (456/457 pass; the 1 failure, `bridge startup > starts exactly one bridge when several commands race`, reproduces identically on unmodified `main` — pre-existing environment flake, unrelated to this change)
- [x] Verified opera-devtools-mcp@0.5.0 build contains opera_register_mcp_server, opera_connect_mcp_server, opera_authenticate_mcp_server, opera_unregister_mcp_server, opera_enable_mcp_server, opera_disable_mcp_server